### PR TITLE
Fix: Auto-detect browser date format and update date parsing logic

### DIFF
--- a/CalendarExtractor.js
+++ b/CalendarExtractor.js
@@ -6,7 +6,6 @@
 (() => {
 // #region Configurations
 const nameOfFile = "schedule";
-const isMonthDayYearFormat = false; // Whether your browser formats your dates as m/d/y. If false, will default to d/m/y
 const keepModuleCode = false; // Whether you want to keep the module code in the name
 const keepModuleType = true; // Whether you want to keep module type in the name (eg: Lecture/Cohort Based Learning)
 // #endregion
@@ -34,6 +33,13 @@ const MODULE_NAME_MISSPELLINGS = {
 //#endregion
 
 // #region Helper Functions
+// Auto-detect browser date format (m/d/y vs d/m/y)
+const isMonthDayYearFormat = typeof Intl !== "undefined" && Intl.DateTimeFormat?.prototype.formatToParts
+    && (() => {
+        const parts = new Intl.DateTimeFormat(undefined, { day: "numeric", month: "numeric" }).formatToParts(new Date(2000, 0, 13));
+        return parts.findIndex(p => p.type === "month") < parts.findIndex(p => p.type === "day");
+    })();
+
 function timeStrTo24h(timeStr) {
     // Account for different browsers displaying time as 12h vs 24h
     const is12H = timeStr.endsWith("AM") || timeStr.endsWith("PM");
@@ -81,12 +87,13 @@ function parseClasses(classTable) {
 
         // Get date
         // Dates are formatted as "Date - Date" but it's always the same date so we just need to take the first one
-        let date = row.querySelector('[id^="MTG_DATES"]').textContent.split(" ")[0];
-        let [ day, month, year ] = date.split('/');
+        let date = row.querySelector('[id^="MTG_DATES"]').textContent.trim().split(/\s+/)[0];
+        let [a, b, year] = date.split('/');
+        let [day, month] = [a, b];
         
-        // Sometimes the date is formatted as month/day/year instead, so check if that's the case. If so, swap accordingly
-        if (isMonthDayYearFormat)
-            [day, month] = [month, day];
+        // If unambiguous, infer from values; otherwise fall back to locale detection
+        if ((+a <= 12 && +b > 12) || (+a <= 12 && +b <= 12 && isMonthDayYearFormat))
+            [day, month] = [b, a];
         date = { day, month, year };
 
         return {

--- a/README.md
+++ b/README.md
@@ -14,16 +14,9 @@ Feel free to reach out if you have any issues/ways to make this script better! :
 
 4. Copy the [CalendarExtractor.js](https://github.com/butter9fe/SUTD-Timetable-Extractor/blob/main/CalendarExtractor.js "`CalendarExtractor.js`") code (just click on the little Copy button next to Raw)
 
-5. Check if your browser formats dates as `month/day/year`. If so, paste the code into an IDE/notepad first and change `isMonthDayYearFormat` to `true`! Then copy it again.
+5. Press `Ctrl + Shift + J (Windows)`/`Cmd + Options + J (Mac)`, go to the Console tab, paste in your code, and press `Enter`
 
-| <img width="537" height="132" alt="image" src="https://github.com/user-attachments/assets/ac01a975-a8f9-4bc3-8749-f72fe8a91398" /> 	| <img width="512" height="127" alt="image" src="https://github.com/user-attachments/assets/b400af68-0ff8-4922-a808-9c8477c9395a" /> 	|
-|---	|---	|
-| Month/Day/Year 	| Day/Month/Year 	|
-<img width="1216" height="160" alt="image" src="https://github.com/user-attachments/assets/6c9dcfb6-f761-435b-9ce9-e9b7bba071ba" />
-
-6. Press `Ctrl + Shift + J (Windows)`/`Cmd + Options + J (Mac)`, go to the Console tab, paste in your code, and press `Enter`
-
-7. After it's done, the `.ics` file would be downloaded and you can import it to your calendar app!
+6. After it's done, the `.ics` file would be downloaded and you can import it to your calendar app!
 
 # Customizations
 At the top of the file, you can modify the following to tweak the events to your liking:


### PR DESCRIPTION
uses `formatToParts()` to determine date format